### PR TITLE
feat: reportCommunication and fix: deleteCommunication

### DIFF
--- a/src/main/java/me/vinceh121/jkdecole/JKdecole.java
+++ b/src/main/java/me/vinceh121/jkdecole/JKdecole.java
@@ -291,7 +291,7 @@ public class JKdecole {
 	}
 
 	private JsonNode makeDeleteRequest(String request) throws ClientProtocolException, IOException {
-		final HttpDelete delete = new HttpDelete(this.endPoint + (request.endsWith("/") ? request : request + '/')+new Date().getTime());
+		final HttpDelete delete = new HttpDelete(this.endPoint + (request.endsWith("/") ? request : request + '/')+ "?_=" + new Date().getTime());
 		this.addHeaders(delete);
 		return this.makeRequest(delete);
 	}

--- a/src/main/java/me/vinceh121/jkdecole/JKdecole.java
+++ b/src/main/java/me/vinceh121/jkdecole/JKdecole.java
@@ -8,6 +8,7 @@ import java.util.List;
 import me.vinceh121.jkdecole.entities.homework.Agenda;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -159,7 +160,15 @@ public class JKdecole {
 	}
 
 	public void deleteCommunication(final long id) throws ClientProtocolException, IOException {
-		this.makePutRequest("messagerie/communication/supprimer/" + id);
+		this.makeDeleteRequest("messagerie/communication/supprimer/" + id);
+	}
+
+	public void reportCommunication(final long id) throws ClientProtocolException, IOException {
+		this.makePutRequest("messagerie/communication/signaler/" + id);
+	}
+
+	public void setCommunicationRead(final long id) throws ClientProtocolException, IOException {
+		this.makePutRequest("messagerie/communication/lu/" + id);
 	}
 
 	public UserInfo getUserInfo()
@@ -169,8 +178,7 @@ public class JKdecole {
 
 	public List<Article> getNews() throws ClientProtocolException, IOException {
 		final JsonNode obj = this.makeGetRequest("actualites/idetablissement/" + this.idEstablishment);
-		final List<Article> news = this.mapper.readValue(obj.traverse(), new TypeReference<List<Article>>() {});
-		return news;
+		return this.mapper.readValue(obj.traverse(), new TypeReference<List<Article>>() {});
 	}
 
 	public Calendar getCalendar()
@@ -280,6 +288,12 @@ public class JKdecole {
 		final HttpPut put = new HttpPut(this.endPoint + request + "?_=" + new Date().getTime());
 		this.addHeaders(put);
 		return this.makeRequest(put);
+	}
+
+	private JsonNode makeDeleteRequest(String request) throws ClientProtocolException, IOException {
+		final HttpDelete delete = new HttpDelete(this.endPoint + (request.endsWith("/") ? request : request + '/')+new Date().getTime());
+		this.addHeaders(delete);
+		return this.makeRequest(delete);
 	}
 
 	private void addHeaders(final HttpUriRequest request) {


### PR DESCRIPTION
Salut,
Il me semble que pour supprimer une communication on appelle l'API en DELETE alors j'ai modifié la méthode `makeDeleteRequest`.
J'ai aussi ajouté la méthode `reportCommunication `pour signaler un fil de discussion et `setCommunicationRead `pour marquer une communication comme étant lue.
Si jamais ça t'intéresse, j'ai créé [ce repo github](https://github.com/maelgangloff/kdecole-api) qui tente de faire l'intégration de l'API K-D'ECOLE sur Node.js.
Pour mettre au point mon intégration, j'ai fait du reverse-engineering sur l'application mobile de mon ENT (Mon Bureau Numérique) et du coup j'ai fait une liste de tout les endpoints.


Bien cordialement,
Maël Gangloff